### PR TITLE
feature/implement_model_presets

### DIFF
--- a/include/models/config/modelSettings.h
+++ b/include/models/config/modelSettings.h
@@ -910,6 +910,16 @@ struct ModelPreset
 	std::string model;
 
 	/**
+	 * @brief Load settings specific to this preset.
+	 *
+	 * GPU layers, context size, batch size, and other model loading
+	 * parameters optimized for this preset's use case.
+	 *
+	 * @see LoadSettings for parameter documentation
+	 */
+	LoadSettings load;
+
+	/**
 	 * @brief Inference settings specific to this preset.
 	 *
 	 * Sampling and generation parameters optimized for this

--- a/include/panels/modelsPanel.h
+++ b/include/panels/modelsPanel.h
@@ -147,6 +147,28 @@ class ModelsPanel
 	/** Refresh model list from ModelsIni singleton. */
 	void refreshModelList();
 
+	// =========================================================================
+	// Preset State
+	// =========================================================================
+	std::vector<Config::ModelPreset>
+		m_presetsForModel;						   // filtered to current model
+	std::vector<std::string> m_presetDisplayNames; // names for Menu component
+	int m_selectedPresetIndex = -1;				   // -1 = none selected
+	std::string m_editingPresetName;			   // bound to editable input
+	std::string m_presetStatus; // status message (e.g. "Saved", "Name in use")
+
+	/** Reload presets from ModelsIni for the currently selected model. */
+	void refreshPresetsForModel();
+
+	/** Apply a preset's load + inference values into all member state. */
+	void applyPreset(const Config::ModelPreset &preset);
+
+	/** Write current member state back to the selected preset in models.ini. */
+	void saveCurrentToPreset();
+
+	/** Rename the selected preset. */
+	void renameSelectedPreset(const std::string &newName);
+
 	/**
 	 * @brief Check if a model path should be filtered out based on fileFilter
 	 * patterns.

--- a/include/utility/modelsIni.h
+++ b/include/utility/modelsIni.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "modelSettings.h"
+
+#include <optional>
 #include <string>
 #include <vector>
 #include <map>
@@ -70,6 +73,45 @@ class ModelsIni
 	 * @return Map of key-value pairs
 	 */
 	std::map<std::string, std::string> getGlobalDefaults() const;
+
+	// ----- Preset read methods -----
+
+	/**
+	 * @brief Parse a section into a ModelPreset.
+	 * @param sectionName The INI section name
+	 * @return The preset, or nullopt if section unknown
+	 */
+	std::optional<Config::ModelPreset>
+	getPreset(const std::string &sectionName) const;
+
+	/**
+	 * @brief Return all presets whose "model" key matches the given path.
+	 * @param modelPath The model file path to match
+	 * @return Vector of matching presets
+	 */
+	std::vector<Config::ModelPreset>
+	getPresetsForModel(const std::string &modelPath) const;
+
+	// ----- Preset write methods -----
+
+	/**
+	 * @brief Persist a preset (creates section if new, overwrites if exists).
+	 * Writes atomically via temp file + rename.
+	 * @return true on success
+	 */
+	bool savePreset(const Config::ModelPreset &preset);
+
+	/**
+	 * @brief Rename a section in-place (preserves all key-value pairs).
+	 * @return true on success
+	 */
+	bool renamePreset(const std::string &oldName, const std::string &newName);
+
+	/**
+	 * @brief Delete a section from the INI file.
+	 * @return true on success
+	 */
+	bool deletePreset(const std::string &sectionName);
 
   private:
 	ModelsIni() = default;

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -346,6 +346,7 @@ void to_json(json &j, const ModelPreset &v)
 {
 	j["name"] = v.name;
 	j["model"] = v.model;
+	j["load"] = v.load;
 	j["inference"] = v.inference;
 }
 
@@ -353,6 +354,8 @@ void from_json(const json &j, ModelPreset &v)
 {
 	v.name = j.value("name", v.name);
 	v.model = j.value("model", v.model);
+	if (j.contains("load"))
+		v.load = j["load"].get<LoadSettings>();
 	if (j.contains("inference"))
 		v.inference = j["inference"].get<InferenceSettings>();
 }

--- a/src/ui/panels/modelsPanel.cpp
+++ b/src/ui/panels/modelsPanel.cpp
@@ -565,6 +565,91 @@ Component ModelsPanel::component()
 	auto fitCb = Checkbox("", &m_fit, cbOpt);
 
 	// -----------------------------------------------------------------------
+	// Preset components
+	// -----------------------------------------------------------------------
+	// Refresh presets for the initially selected model
+	refreshPresetsForModel();
+
+	auto presetMenuOpt = MenuOption::Vertical();
+	presetMenuOpt.on_change = [this] {
+		if (m_selectedPresetIndex >= 0 &&
+			m_selectedPresetIndex < static_cast<int>(m_presetsForModel.size())) {
+			applyPreset(m_presetsForModel[m_selectedPresetIndex]);
+			m_editingPresetName = m_presetsForModel[m_selectedPresetIndex].name;
+			m_presetStatus.clear();
+		}
+	};
+	presetMenuOpt.entries_option.transform = [=](const EntryState &s) {
+		auto e = text(s.label);
+		if (s.active)
+			e |= color(toggleOnColor);
+		else
+			e |= color(toggleOffColor);
+		if (s.focused)
+			e |= bold;
+		return e;
+	};
+	auto presetMenu =
+		Menu(&m_presetDisplayNames, &m_selectedPresetIndex, presetMenuOpt);
+
+	InputOption presetNameOpt;
+	presetNameOpt.multiline = false;
+	presetNameOpt.transform = [=](InputState state) {
+		auto e = state.element | align_right;
+		if (state.is_placeholder)
+			return e | color(toggleOffColor);
+		return e | color(toggleOnColor);
+	};
+	auto presetNameInput =
+		Input(&m_editingPresetName, "preset name", presetNameOpt);
+
+	auto presetBtnStyle = ButtonOption::Animated();
+	presetBtnStyle.transform = [=](const EntryState &s) {
+		auto e = text(s.label) | color(Color::MagentaLight);
+		if (s.focused)
+			e |= bold;
+		return e | center;
+	};
+
+	auto presetSaveBtn = Button(
+		"Save",
+		[this] { saveCurrentToPreset(); },
+		presetBtnStyle);
+
+	auto presetRenameBtn = Button(
+		"Rename",
+		[this] { renameSelectedPreset(m_editingPresetName); },
+		presetBtnStyle);
+
+	auto presetNewBtn = Button(
+		"+ New",
+		[this] {
+			m_selectedPresetIndex = -1;
+			std::string base =
+				m_selectedModelName.empty() ? "preset" : m_selectedModelName;
+			m_editingPresetName = base + "-new";
+			m_presetStatus.clear();
+		},
+		presetBtnStyle);
+
+	auto presetDeleteBtn = Button(
+		"Delete",
+		[this] {
+			if (m_selectedPresetIndex >= 0 &&
+				m_selectedPresetIndex <
+					static_cast<int>(m_presetsForModel.size())) {
+				std::string name = m_presetsForModel[m_selectedPresetIndex].name;
+				if (ModelsIni::instance().deletePreset(name)) {
+					m_presetStatus = "Deleted";
+					m_selectedPresetIndex = -1;
+					m_editingPresetName.clear();
+					refreshPresetsForModel();
+				}
+			}
+		},
+		presetBtnStyle);
+
+	// -----------------------------------------------------------------------
 	// Model Selection Dropdown, START/STOP, and LOAD/UNLOAD Buttons
 	// -----------------------------------------------------------------------
 	// Model dropdown - selecting a model updates m_modelPath which is used when
@@ -662,6 +747,13 @@ Component ModelsPanel::component()
 			mmapCb,
 			mlockCb,
 			fitCb,
+			// Presets
+			presetMenu,
+			presetNameInput,
+			presetSaveBtn,
+			presetRenameBtn,
+			presetNewBtn,
+			presetDeleteBtn,
 			// Footer: model dropdown and single server button
 			modelDropdown,
 			serverButton,
@@ -677,7 +769,27 @@ Component ModelsPanel::component()
 		}),
 	});
 
-	m_component = Renderer(container, [=, this] {
+	// Track model dropdown changes to refresh presets
+	int lastModelIndex = m_modelDropdownIndex;
+
+	m_component = Renderer(container, [=, this]() mutable {
+		// Detect model dropdown change
+		if (m_modelDropdownIndex != lastModelIndex) {
+			lastModelIndex = m_modelDropdownIndex;
+			if (m_modelDropdownIndex >= 0 &&
+				m_modelDropdownIndex < static_cast<int>(m_modelNames.size())) {
+				m_selectedModelName = m_modelNames[m_modelDropdownIndex];
+				m_modelPath =
+					ModelsIni::instance().getModelPath(m_selectedModelName);
+			}
+			refreshPresetsForModel();
+			m_selectedPresetIndex = -1;
+			m_editingPresetName.clear();
+			m_presetStatus.clear();
+			updateStartStopLabel();
+			saveConfig();
+		}
+
 		// === Left column: Load Settings ===
 		Elements leftElements;
 		{
@@ -788,13 +900,46 @@ Component ModelsPanel::component()
 		auto leftCol = vbox(std::move(leftElements)) | flex;
 		auto rightCol = vbox(std::move(rightElements)) | flex;
 
-		// Footer section with model dropdown and single server button
-		// Button state:
-		// - Server not running: LOAD (green text)
-		// - Server running, no model: LOAD (green text)
-		// - Server running, model loaded: UNLOAD (red text)
-		// Note: Button text color changes via style, no background color
+		// === Presets panel ===
+		Elements presetElements;
+		if (m_presetDisplayNames.empty()) {
+			presetElements.push_back(
+				text("  No presets — use Save to create one.") |
+				color(Color::GrayDark));
+		} else {
+			presetElements.push_back(presetMenu->Render() | vscroll_indicator |
+									 frame | size(HEIGHT, LESS_THAN, 6));
+		}
+		// Name input + buttons row
+		presetElements.push_back(separatorLight());
+		presetElements.push_back(hbox({
+			text(" Name: ") | color(Color::GrayLight),
+			presetNameInput->Render() | flex,
+			separatorLight(),
+			presetRenameBtn->Render(),
+			separatorLight(),
+			presetSaveBtn->Render(),
+			separatorLight(),
+			presetNewBtn->Render(),
+			separatorLight(),
+			presetDeleteBtn->Render(),
+		}));
+		// Status message
+		if (!m_presetStatus.empty()) {
+			Color statusColor = (m_presetStatus == "Name in use" ||
+								 m_presetStatus == "Save failed" ||
+								 m_presetStatus == "Rename failed")
+									? Color::RedLight
+									: Color::GreenLight;
+			presetElements.push_back(text("  " + m_presetStatus) |
+									 color(statusColor));
+		}
 
+		auto presetsPanel = window(text("Presets") | bold | color(Color::Yellow),
+								   vbox(std::move(presetElements)),
+								   ftxui::EMPTY);
+
+		// Footer section with model dropdown and single server button
 		auto footerRow = hbox({
 			filler(),
 			vbox({
@@ -807,6 +952,7 @@ Component ModelsPanel::component()
 
 		return vbox({
 				   hbox({ leftCol, separatorLight(), rightCol }),
+				   presetsPanel,
 				   filler(),
 				   footerRow,
 			   }) |
@@ -815,6 +961,256 @@ Component ModelsPanel::component()
 
 	return m_component;
 }
+
+// =========================================================================
+// Preset Methods
+// =========================================================================
+
+void ModelsPanel::refreshPresetsForModel()
+{
+	if (m_selectedModelName.empty()) {
+		m_presetsForModel.clear();
+		m_presetDisplayNames.clear();
+		return;
+	}
+	std::string modelPath =
+		ModelsIni::instance().getModelPath(m_selectedModelName);
+	m_presetsForModel = ModelsIni::instance().getPresetsForModel(modelPath);
+	m_presetDisplayNames.clear();
+	for (const auto &p : m_presetsForModel)
+		m_presetDisplayNames.push_back(p.name);
+
+	// Clamp selected index
+	if (m_selectedPresetIndex >= static_cast<int>(m_presetsForModel.size()))
+		m_selectedPresetIndex = -1;
+}
+
+void ModelsPanel::applyPreset(const Config::ModelPreset &preset)
+{
+	// Load settings
+	m_ngpuLayers = preset.load.ngpuLayers;
+	m_ctxSize =
+		preset.load.ctxSize == 0 ? "" : std::to_string(preset.load.ctxSize);
+	m_batchSize = preset.load.batchSize;
+	m_batchSizeStr = std::to_string(m_batchSize);
+	m_parallel = preset.load.parallel;
+	m_parallelStr = m_parallel < 0 ? "-1" : std::to_string(m_parallel);
+
+	// Flash attention dropdown index
+	if (preset.load.flashAttn == "on")
+		m_flashAttnIdx = 1;
+	else if (preset.load.flashAttn == "off")
+		m_flashAttnIdx = 2;
+	else
+		m_flashAttnIdx = 0;
+
+	m_kvOffload = preset.load.kvOffload;
+	m_kvUnified = preset.load.kvUnified;
+	m_mmap = preset.load.mmap;
+	m_mlock = preset.load.mlock;
+	m_fit = preset.load.fit;
+	m_devicePriority = preset.load.devicePriority;
+	m_splitMode = preset.load.splitMode;
+	m_tensorSplit = preset.load.tensorSplit;
+	m_cacheTypeK = preset.load.cacheTypeK;
+	m_cacheTypeV = preset.load.cacheTypeV;
+	m_lora = preset.load.lora;
+	m_mmproj = preset.load.mmproj;
+	m_modelDraft = preset.load.modelDraft;
+	m_draftMax = std::to_string(preset.load.draftMax);
+	m_chatTemplate = preset.load.chatTemplate;
+	m_reasoningFormat = preset.load.reasoningFormat;
+
+	// Dropdown indices for load settings
+	m_splitModeIdx = 0;
+	for (size_t i = 0; i < m_splitModeOptions.size(); ++i) {
+		if (m_splitModeOptions[i] == preset.load.splitMode) {
+			m_splitModeIdx = static_cast<int>(i);
+			break;
+		}
+	}
+	m_cacheTypeKIdx = 0;
+	for (size_t i = 0; i < m_cacheTypeOptions.size(); ++i) {
+		if (m_cacheTypeOptions[i] == preset.load.cacheTypeK) {
+			m_cacheTypeKIdx = static_cast<int>(i);
+			break;
+		}
+	}
+	m_cacheTypeVIdx = 0;
+	for (size_t i = 0; i < m_cacheTypeOptions.size(); ++i) {
+		if (m_cacheTypeOptions[i] == preset.load.cacheTypeV) {
+			m_cacheTypeVIdx = static_cast<int>(i);
+			break;
+		}
+	}
+	m_reasoningFormatIdx = 0;
+	for (size_t i = 0; i < m_reasoningFormatOptions.size(); ++i) {
+		if (m_reasoningFormatOptions[i] == preset.load.reasoningFormat) {
+			m_reasoningFormatIdx = static_cast<int>(i);
+			break;
+		}
+	}
+
+	// Inference settings
+	m_temperature = static_cast<float>(preset.inference.temperature);
+	m_temperatureStr = ui_utils::formatFloat(m_temperature);
+	m_topP = static_cast<float>(preset.inference.topP);
+	m_topPStr = ui_utils::formatFloat(m_topP);
+	m_topK = preset.inference.topK;
+	m_topKStr = std::to_string(m_topK);
+	m_minP = static_cast<float>(preset.inference.minP);
+	m_minPStr = ui_utils::formatFloat(m_minP);
+	m_repeatPenalty = static_cast<float>(preset.inference.repeatPenalty);
+	m_repeatPenaltyStr = ui_utils::formatFloat(m_repeatPenalty);
+	m_presencePenalty = static_cast<float>(preset.inference.presencePenalty);
+	m_presencePenaltyStr = ui_utils::formatFloat(m_presencePenalty);
+	m_frequencyPenalty = static_cast<float>(preset.inference.frequencyPenalty);
+	m_frequencyPenaltyStr = ui_utils::formatFloat(m_frequencyPenalty);
+	m_nPredict = std::to_string(preset.inference.nPredict);
+	m_seed = std::to_string(preset.inference.seed);
+
+	// Persist to config.json so LOAD picks up the values
+	saveConfig();
+
+	spdlog::info("Applied preset '{}'", preset.name);
+}
+
+void ModelsPanel::saveCurrentToPreset()
+{
+	Config::ModelPreset preset;
+
+	// Determine preset name
+	if (m_editingPresetName.empty()) {
+		// Generate default name
+		std::string base =
+			m_selectedModelName.empty() ? "preset" : m_selectedModelName;
+		preset.name = base + "-1";
+		int n = 1;
+		// Ensure unique
+		while (true) {
+			bool found = false;
+			for (const auto &p : m_presetsForModel) {
+				if (p.name == preset.name) {
+					found = true;
+					break;
+				}
+			}
+			if (!found)
+				break;
+			preset.name = base + "-" + std::to_string(++n);
+		}
+		m_editingPresetName = preset.name;
+	} else {
+		preset.name = m_editingPresetName;
+	}
+
+	preset.model = ModelsIni::instance().getModelPath(m_selectedModelName);
+	if (preset.model.empty())
+		preset.model = m_modelPath; // fallback to current model path
+
+	// Load settings from current member state
+	preset.load.modelPath = preset.model;
+	preset.load.ngpuLayers = m_ngpuLayers;
+	try {
+		preset.load.ctxSize = m_ctxSize.empty() ? 0 : std::stoi(m_ctxSize);
+	} catch (...) {
+	}
+	preset.load.batchSize = m_batchSize;
+	preset.load.parallel = m_parallel;
+	preset.load.flashAttn =
+		m_flashAttnOptions[static_cast<size_t>(m_flashAttnIdx)];
+	preset.load.kvOffload = m_kvOffload;
+	preset.load.kvUnified = m_kvUnified;
+	preset.load.mmap = m_mmap;
+	preset.load.mlock = m_mlock;
+	preset.load.fit = m_fit;
+	preset.load.devicePriority = m_devicePriority;
+	preset.load.splitMode = m_splitMode;
+	preset.load.tensorSplit = m_tensorSplit;
+	preset.load.cacheTypeK =
+		m_cacheTypeOptions[static_cast<size_t>(m_cacheTypeKIdx)];
+	preset.load.cacheTypeV =
+		m_cacheTypeOptions[static_cast<size_t>(m_cacheTypeVIdx)];
+	preset.load.lora = m_lora;
+	preset.load.mmproj = m_mmproj;
+	preset.load.modelDraft = m_modelDraft;
+	try {
+		preset.load.draftMax = std::stoi(m_draftMax);
+	} catch (...) {
+	}
+	preset.load.chatTemplate = m_chatTemplate;
+	preset.load.reasoningFormat =
+		m_reasoningFormatOptions[static_cast<size_t>(m_reasoningFormatIdx)];
+
+	// Inference settings
+	preset.inference.temperature = static_cast<double>(m_temperature);
+	preset.inference.topP = static_cast<double>(m_topP);
+	preset.inference.topK = m_topK;
+	preset.inference.minP = static_cast<double>(m_minP);
+	preset.inference.repeatPenalty = static_cast<double>(m_repeatPenalty);
+	preset.inference.presencePenalty = static_cast<double>(m_presencePenalty);
+	preset.inference.frequencyPenalty = static_cast<double>(m_frequencyPenalty);
+	try {
+		preset.inference.nPredict = std::stoi(m_nPredict);
+	} catch (...) {
+	}
+	try {
+		preset.inference.seed = std::stoi(m_seed);
+	} catch (...) {
+	}
+
+	if (ModelsIni::instance().savePreset(preset)) {
+		m_presetStatus = "Saved";
+		refreshPresetsForModel();
+		// Select the saved preset
+		for (int i = 0; i < static_cast<int>(m_presetsForModel.size()); ++i) {
+			if (m_presetsForModel[i].name == preset.name) {
+				m_selectedPresetIndex = i;
+				break;
+			}
+		}
+	} else {
+		m_presetStatus = "Save failed";
+	}
+}
+
+void ModelsPanel::renameSelectedPreset(const std::string &newName)
+{
+	if (m_selectedPresetIndex < 0 ||
+		m_selectedPresetIndex >= static_cast<int>(m_presetsForModel.size())) {
+		return;
+	}
+
+	std::string oldName = m_presetsForModel[m_selectedPresetIndex].name;
+	if (oldName == newName || newName.empty())
+		return;
+
+	// Check for duplicate name
+	for (const auto &p : m_presetsForModel) {
+		if (p.name == newName) {
+			m_presetStatus = "Name in use";
+			return;
+		}
+	}
+
+	if (ModelsIni::instance().renamePreset(oldName, newName)) {
+		m_presetStatus = "Renamed";
+		refreshPresetsForModel();
+		// Re-select by new name
+		for (int i = 0; i < static_cast<int>(m_presetsForModel.size()); ++i) {
+			if (m_presetsForModel[i].name == newName) {
+				m_selectedPresetIndex = i;
+				break;
+			}
+		}
+	} else {
+		m_presetStatus = "Rename failed";
+	}
+}
+
+// =========================================================================
+// Server Methods
+// =========================================================================
 
 void ModelsPanel::onStartStopClicked()
 {

--- a/src/utility/modelsIni.cpp
+++ b/src/utility/modelsIni.cpp
@@ -1,7 +1,10 @@
 #include "modelsIni.h"
 #include "configManager.h"
 
+#include <algorithm>
+#include <filesystem>
 #include <fstream>
+#include <set>
 #include <spdlog/spdlog.h>
 #include <sstream>
 
@@ -169,4 +172,527 @@ std::map<std::string, std::string> ModelsIni::getGlobalDefaults() const
 		return {};
 	}
 	return globalIt->second;
+}
+
+// =========================================================================
+// Serialisation helpers (INI key <-> struct)
+// =========================================================================
+
+namespace {
+
+/// Helper: convert string to bool ("true"/"on"/"1" → true)
+bool toBool(const std::string &v, bool fallback)
+{
+	if (v.empty())
+		return fallback;
+	std::string lv = v;
+	std::transform(lv.begin(), lv.end(), lv.begin(), [](unsigned char c) {
+		return static_cast<char>(std::tolower(c));
+	});
+	if (lv == "true" || lv == "on" || lv == "1")
+		return true;
+	if (lv == "false" || lv == "off" || lv == "0")
+		return false;
+	return fallback;
+}
+
+std::string fromBool(bool v)
+{
+	return v ? "true" : "false";
+}
+
+int toInt(const std::string &v, int fallback)
+{
+	try {
+		return std::stoi(v);
+	} catch (...) {
+		return fallback;
+	}
+}
+
+double toDouble(const std::string &v, double fallback)
+{
+	try {
+		return std::stod(v);
+	} catch (...) {
+		return fallback;
+	}
+}
+
+/// Try two keys (primary kebab-case, fallback underscore/abbreviated)
+std::string getAny(const std::map<std::string, std::string> &kv,
+				   const std::string &k1,
+				   const std::string &k2 = "")
+{
+	auto it = kv.find(k1);
+	if (it != kv.end())
+		return it->second;
+	if (!k2.empty()) {
+		it = kv.find(k2);
+		if (it != kv.end())
+			return it->second;
+	}
+	return "";
+}
+
+/// Build LoadSettings from INI key-value pairs
+/// Accepts both kebab-case (existing format) and abbreviated keys
+Config::LoadSettings
+iniToLoadSettings(const std::map<std::string, std::string> &kv)
+{
+	Config::LoadSettings s;
+
+	auto v = getAny(kv, "n-gpu-layers", "ngl");
+	if (!v.empty())
+		s.ngpuLayers = v;
+	v = getAny(kv, "ctx-size", "ctx");
+	if (!v.empty())
+		s.ctxSize = toInt(v, s.ctxSize);
+	v = getAny(kv, "batch-size", "batch");
+	if (!v.empty())
+		s.batchSize = toInt(v, s.batchSize);
+	v = getAny(kv, "ubatch-size", "ubatch");
+	if (!v.empty())
+		s.ubatchSize = toInt(v, s.ubatchSize);
+	v = getAny(kv, "parallel");
+	if (!v.empty())
+		s.parallel = toInt(v, s.parallel);
+	v = getAny(kv, "flash-attn", "flash_attn");
+	if (!v.empty())
+		s.flashAttn = v;
+	v = getAny(kv, "kv-offload", "kv_offload");
+	if (!v.empty())
+		s.kvOffload = toBool(v, s.kvOffload);
+	v = getAny(kv, "kv-unified", "kv_unified");
+	if (!v.empty())
+		s.kvUnified = toBool(v, s.kvUnified);
+	v = getAny(kv, "mmap");
+	if (!v.empty())
+		s.mmap = toBool(v, s.mmap);
+	v = getAny(kv, "mlock");
+	if (!v.empty())
+		s.mlock = toBool(v, s.mlock);
+	v = getAny(kv, "fit");
+	if (!v.empty())
+		s.fit = toBool(v, s.fit);
+	v = getAny(kv, "split-mode", "split_mode");
+	if (!v.empty())
+		s.splitMode = v;
+	v = getAny(kv, "tensor-split", "tensor_split");
+	if (!v.empty())
+		s.tensorSplit = v;
+	v = getAny(kv, "device-priority", "device_priority");
+	if (!v.empty())
+		s.devicePriority = v;
+	v = getAny(kv, "cache-type-k", "cache_type_k");
+	if (!v.empty())
+		s.cacheTypeK = v;
+	v = getAny(kv, "cache-type-v", "cache_type_v");
+	if (!v.empty())
+		s.cacheTypeV = v;
+	v = getAny(kv, "lora");
+	if (!v.empty())
+		s.lora = v;
+	v = getAny(kv, "mmproj");
+	if (!v.empty())
+		s.mmproj = v;
+	v = getAny(kv, "model-draft", "model_draft");
+	if (!v.empty())
+		s.modelDraft = v;
+	v = getAny(kv, "draft-max", "draft_max");
+	if (!v.empty())
+		s.draftMax = toInt(v, s.draftMax);
+	v = getAny(kv, "chat-template", "chat_template");
+	if (!v.empty())
+		s.chatTemplate = v;
+	v = getAny(kv, "reasoning-format", "reasoning_format");
+	if (!v.empty())
+		s.reasoningFormat = v;
+	v = getAny(kv, "threads");
+	if (!v.empty())
+		s.threads = toInt(v, s.threads);
+	v = getAny(kv, "threads-batch");
+	if (!v.empty())
+		s.threadsBatch = toInt(v, s.threadsBatch);
+
+	return s;
+}
+
+/// Build InferenceSettings from INI key-value pairs (keys already stripped of
+/// "inf." prefix if present). Accepts both kebab-case and underscore keys.
+Config::InferenceSettings
+iniToInferenceSettings(const std::map<std::string, std::string> &kv)
+{
+	Config::InferenceSettings s;
+
+	auto v = getAny(kv, "temp", "temperature");
+	if (!v.empty())
+		s.temperature = toDouble(v, s.temperature);
+	v = getAny(kv, "top-p", "top_p");
+	if (!v.empty())
+		s.topP = toDouble(v, s.topP);
+	v = getAny(kv, "top-k", "top_k");
+	if (!v.empty())
+		s.topK = toInt(v, s.topK);
+	v = getAny(kv, "min-p", "min_p");
+	if (!v.empty())
+		s.minP = toDouble(v, s.minP);
+	v = getAny(kv, "repeat-penalty", "repeat_penalty");
+	if (!v.empty())
+		s.repeatPenalty = toDouble(v, s.repeatPenalty);
+	v = getAny(kv, "presence-penalty", "presence_penalty");
+	if (!v.empty())
+		s.presencePenalty = toDouble(v, s.presencePenalty);
+	v = getAny(kv, "frequency-penalty", "frequency_penalty");
+	if (!v.empty())
+		s.frequencyPenalty = toDouble(v, s.frequencyPenalty);
+	v = getAny(kv, "n-predict", "n_predict");
+	if (!v.empty())
+		s.nPredict = toInt(v, s.nPredict);
+	v = getAny(kv, "seed");
+	if (!v.empty())
+		s.seed = toInt(v, s.seed);
+	v = getAny(kv, "samplers");
+	if (!v.empty())
+		s.samplers = v;
+	v = getAny(kv, "repeat-last-n");
+	if (!v.empty())
+		s.repeatLastN = toInt(v, s.repeatLastN);
+
+	return s;
+}
+
+/// Convert LoadSettings to INI key-value pairs (kebab-case, matching
+/// llama-server CLI format). Returns lines as ordered vector to control output
+/// order.
+std::vector<std::pair<std::string, std::string>>
+loadSettingsToIni(const Config::LoadSettings &s)
+{
+	std::vector<std::pair<std::string, std::string>> kv;
+	kv.emplace_back("batch-size", std::to_string(s.batchSize));
+	kv.emplace_back("ubatch-size", std::to_string(s.ubatchSize));
+	kv.emplace_back("ctx-size", std::to_string(s.ctxSize));
+	kv.emplace_back("parallel", std::to_string(s.parallel));
+	kv.emplace_back("n-gpu-layers", s.ngpuLayers.empty() ? "all" : s.ngpuLayers);
+	kv.emplace_back("flash-attn", s.flashAttn.empty() ? "on" : s.flashAttn);
+	kv.emplace_back("fit", s.fit ? "on" : "off");
+	kv.emplace_back("mmap", s.mmap ? "1" : "0");
+	kv.emplace_back("mlock", s.mlock ? "1" : "0");
+	kv.emplace_back("kv-offload", s.kvOffload ? "1" : "0");
+	kv.emplace_back("cache-type-k", s.cacheTypeK);
+	kv.emplace_back("cache-type-v", s.cacheTypeV);
+	kv.emplace_back("threads", std::to_string(s.threads));
+	kv.emplace_back("threads-batch", std::to_string(s.threadsBatch));
+	if (!s.splitMode.empty())
+		kv.emplace_back("split-mode", s.splitMode);
+	if (!s.tensorSplit.empty())
+		kv.emplace_back("tensor-split", s.tensorSplit);
+	if (!s.devicePriority.empty())
+		kv.emplace_back("device-priority", s.devicePriority);
+	if (!s.lora.empty())
+		kv.emplace_back("lora", s.lora);
+	if (!s.mmproj.empty())
+		kv.emplace_back("mmproj", s.mmproj);
+	if (!s.modelDraft.empty())
+		kv.emplace_back("model-draft", s.modelDraft);
+	if (s.draftMax != -1)
+		kv.emplace_back("draft-max", std::to_string(s.draftMax));
+	if (!s.chatTemplate.empty())
+		kv.emplace_back("chat-template", s.chatTemplate);
+	if (!s.reasoningFormat.empty())
+		kv.emplace_back("reasoning-format", s.reasoningFormat);
+	return kv;
+}
+
+/// Convert InferenceSettings to INI key-value pairs (kebab-case, no prefix)
+std::vector<std::pair<std::string, std::string>>
+inferenceSettingsToIni(const Config::InferenceSettings &s)
+{
+	auto fmt = [](double v) {
+		std::ostringstream os;
+		os << v;
+		return os.str();
+	};
+	std::vector<std::pair<std::string, std::string>> kv;
+	kv.emplace_back("temp", fmt(s.temperature));
+	kv.emplace_back("top-p", fmt(s.topP));
+	kv.emplace_back("top-k", std::to_string(s.topK));
+	kv.emplace_back("min-p", fmt(s.minP));
+	kv.emplace_back("repeat-penalty", fmt(s.repeatPenalty));
+	kv.emplace_back("repeat-last-n", std::to_string(s.repeatLastN));
+	kv.emplace_back("presence-penalty", fmt(s.presencePenalty));
+	kv.emplace_back("frequency-penalty", fmt(s.frequencyPenalty));
+	kv.emplace_back("seed", std::to_string(s.seed));
+	kv.emplace_back("n-predict", std::to_string(s.nPredict));
+	if (!s.samplers.empty())
+		kv.emplace_back("samplers", s.samplers);
+	return kv;
+}
+
+/// Sanitise a preset name for use as an INI section header
+std::string sanitiseSectionName(const std::string &name)
+{
+	std::string out;
+	out.reserve(name.size());
+	for (char c : name) {
+		if (c != '[' && c != ']')
+			out += c;
+	}
+	return trim(out);
+}
+
+/// Read file lines (preserving comments and blank lines)
+std::vector<std::string> readFileLines(const std::string &path)
+{
+	std::vector<std::string> lines;
+	std::ifstream file(path);
+	std::string line;
+	while (std::getline(file, line))
+		lines.push_back(line);
+	return lines;
+}
+
+/// Atomically write lines to file via temp + rename
+bool writeFileAtomic(const std::string &path,
+					 const std::vector<std::string> &lines)
+{
+	std::string tmpPath = path + ".tmp";
+	{
+		std::ofstream out(tmpPath);
+		if (!out.is_open()) {
+			spdlog::error("Failed to open temp file for writing: {}", tmpPath);
+			return false;
+		}
+		for (const auto &line : lines)
+			out << line << "\n";
+	}
+
+	std::error_code ec;
+	std::filesystem::rename(tmpPath, path, ec);
+	if (ec) {
+		spdlog::error("Failed to rename temp file: {}", ec.message());
+		std::filesystem::remove(tmpPath, ec);
+		return false;
+	}
+	return true;
+}
+
+/// Find the line range [start, end) for a section in the file lines.
+/// Returns {-1, -1} if not found. 'start' is the [section] header line.
+std::pair<int, int> findSectionRange(const std::vector<std::string> &lines,
+									 const std::string &sectionName)
+{
+	int start = -1;
+	for (int i = 0; i < static_cast<int>(lines.size()); ++i) {
+		std::string trimmed = trim(lines[i]);
+		if (trimmed.size() >= 2 && trimmed.front() == '[' &&
+			trimmed.back() == ']') {
+			std::string name = trim(trimmed.substr(1, trimmed.size() - 2));
+			if (name == sectionName) {
+				start = i;
+			} else if (start >= 0) {
+				return { start, i };
+			}
+		}
+	}
+	if (start >= 0)
+		return { start, static_cast<int>(lines.size()) };
+	return { -1, -1 };
+}
+
+} // namespace
+
+// =========================================================================
+// Preset read methods
+// =========================================================================
+
+std::optional<Config::ModelPreset>
+ModelsIni::getPreset(const std::string &sectionName) const
+{
+	auto it = m_sections.find(sectionName);
+	if (it == m_sections.end() || sectionName == "*")
+		return std::nullopt;
+
+	const auto &kv = it->second;
+	Config::ModelPreset preset;
+	preset.name = sectionName;
+
+	auto modelIt = kv.find("model");
+	if (modelIt != kv.end())
+		preset.model = modelIt->second;
+
+	// Known inference keys (kebab-case, no prefix)
+	static const std::set<std::string> inferenceKeys = {
+		"temp",
+		"temperature",
+		"top-p",
+		"top_p",
+		"top-k",
+		"top_k",
+		"min-p",
+		"min_p",
+		"repeat-penalty",
+		"repeat_penalty",
+		"repeat-last-n",
+		"presence-penalty",
+		"presence_penalty",
+		"frequency-penalty",
+		"frequency_penalty",
+		"n-predict",
+		"n_predict",
+		"seed",
+		"samplers",
+	};
+
+	// Split keys into load keys and inference keys
+	std::map<std::string, std::string> loadKv;
+	std::map<std::string, std::string> infKv;
+	for (const auto &[k, v] : kv) {
+		if (k == "model")
+			continue;
+		if (k.rfind("inf.", 0) == 0) {
+			infKv[k.substr(4)] = v; // strip "inf." prefix
+		} else if (inferenceKeys.count(k)) {
+			infKv[k] = v; // non-prefixed inference key
+		} else {
+			loadKv[k] = v;
+		}
+	}
+
+	preset.load = iniToLoadSettings(loadKv);
+	preset.load.modelPath = preset.model; // sync model path
+	preset.inference = iniToInferenceSettings(infKv);
+
+	return preset;
+}
+
+std::vector<Config::ModelPreset>
+ModelsIni::getPresetsForModel(const std::string &modelPath) const
+{
+	std::vector<Config::ModelPreset> result;
+	for (const auto &[name, kv] : m_sections) {
+		if (name == "*")
+			continue;
+		auto modelIt = kv.find("model");
+		if (modelIt != kv.end() && modelIt->second == modelPath) {
+			auto preset = getPreset(name);
+			if (preset)
+				result.push_back(*preset);
+		}
+	}
+	return result;
+}
+
+// =========================================================================
+// Preset write methods
+// =========================================================================
+
+bool ModelsIni::savePreset(const Config::ModelPreset &preset)
+{
+	std::string name = sanitiseSectionName(preset.name);
+	if (name.empty()) {
+		spdlog::error("Cannot save preset with empty name");
+		return false;
+	}
+
+	// Build ordered section lines
+	auto loadKv = loadSettingsToIni(preset.load);
+	auto infKv = inferenceSettingsToIni(preset.inference);
+
+	// Read current file
+	auto lines = readFileLines(m_filePath);
+
+	// Find existing section
+	auto [start, end] = findSectionRange(lines, name);
+
+	// Build replacement lines with comments for readability
+	std::vector<std::string> sectionLines;
+	sectionLines.push_back("[" + name + "]");
+	sectionLines.push_back("model = " + preset.model);
+	sectionLines.push_back("; Load settings");
+	for (const auto &[k, v] : loadKv)
+		sectionLines.push_back(k + " = " + v);
+	sectionLines.push_back("; Inference settings");
+	for (const auto &[k, v] : infKv)
+		sectionLines.push_back(k + " = " + v);
+	sectionLines.push_back(""); // blank line after section
+
+	if (start >= 0) {
+		// Replace existing section
+		lines.erase(lines.begin() + start, lines.begin() + end);
+		lines.insert(lines.begin() + start,
+					 sectionLines.begin(),
+					 sectionLines.end());
+	} else {
+		// Append new section at end
+		if (!lines.empty() && !lines.back().empty())
+			lines.push_back("");
+		lines.insert(lines.end(), sectionLines.begin(), sectionLines.end());
+	}
+
+	if (!writeFileAtomic(m_filePath, lines)) {
+		spdlog::error("Failed to write models.ini");
+		return false;
+	}
+
+	// Reload in-memory state
+	load();
+	spdlog::info("Saved preset '{}' to models.ini", name);
+	return true;
+}
+
+bool ModelsIni::renamePreset(const std::string &oldName,
+							 const std::string &newName)
+{
+	std::string sanitised = sanitiseSectionName(newName);
+	if (sanitised.empty() || sanitised == "*") {
+		spdlog::error("Invalid preset name: '{}'", newName);
+		return false;
+	}
+
+	// Check new name doesn't already exist
+	if (m_sections.find(sanitised) != m_sections.end() && sanitised != oldName) {
+		spdlog::warn("Preset name '{}' already exists", sanitised);
+		return false;
+	}
+
+	auto lines = readFileLines(m_filePath);
+	auto [start, end] = findSectionRange(lines, oldName);
+	if (start < 0) {
+		spdlog::error("Preset '{}' not found for rename", oldName);
+		return false;
+	}
+
+	// Replace the section header line
+	lines[start] = "[" + sanitised + "]";
+
+	if (!writeFileAtomic(m_filePath, lines)) {
+		spdlog::error("Failed to write models.ini during rename");
+		return false;
+	}
+
+	load();
+	spdlog::info("Renamed preset '{}' -> '{}'", oldName, sanitised);
+	return true;
+}
+
+bool ModelsIni::deletePreset(const std::string &sectionName)
+{
+	auto lines = readFileLines(m_filePath);
+	auto [start, end] = findSectionRange(lines, sectionName);
+	if (start < 0) {
+		spdlog::warn("Preset '{}' not found for deletion", sectionName);
+		return false;
+	}
+
+	lines.erase(lines.begin() + start, lines.begin() + end);
+
+	if (!writeFileAtomic(m_filePath, lines)) {
+		spdlog::error("Failed to write models.ini during delete");
+		return false;
+	}
+
+	load();
+	spdlog::info("Deleted preset '{}'", sectionName);
+	return true;
 }


### PR DESCRIPTION
Closes #27 

- Save/load/rename/delete named configurations for llama-server settings (load params + inference params)
- Presets stored in models.ini, filtered by model path
- UI: dropdown to select preset, input field for name, Save/Rename/New/Delete buttons